### PR TITLE
Added MySQL configuration based on my-huge.cnf

### DIFF
--- a/modules/mysql/files/my.cnf
+++ b/modules/mysql/files/my.cnf
@@ -1,0 +1,88 @@
+# Example MariaDB config file for very large systems.
+#
+# This is for a large system with memory of 1G-2G where the system runs mainly
+# MariaDB.
+#
+# MariaDB programs look for option files in a set of
+# locations which depend on the deployment platform.
+# You can copy this option file to one of those
+# locations. For information about these locations, do:
+# 'my_print_defaults --help' and see what is printed under
+# Default options are read from the following files in the given order:
+# More information at: http://dev.mysql.com/doc/mysql/en/option-files.html
+#
+# In this file, you can use all long options that a program supports.
+# If you want to know which options a program supports, run the program
+# with the "--help" option.
+
+# The following options will be passed to all MySQL clients
+[client]
+#password	= your_password
+port		= 3306
+socket		= /var/lib/mysql/mysql.sock
+
+# Here follows entries for some specific programs
+
+# The MySQL server
+[mysqld]
+port		= 3306
+socket		= /var/lib/mysql/mysql.sock
+skip-external-locking
+key_buffer_size = 384M
+max_allowed_packet = 50M
+table_open_cache = 512
+sort_buffer_size = 2M
+read_buffer_size = 2M
+read_rnd_buffer_size = 8M
+myisam_sort_buffer_size = 64M
+thread_cache_size = 8
+query_cache_size = 32M
+# Try number of CPU's*2 for thread_concurrency
+thread_concurrency = 2
+
+character-set-server=utf8
+collation-server=utf8_unicode_ci
+
+# Point the following paths to a dedicated disk
+#tmpdir		= /tmp/
+
+# Don't listen on a TCP/IP port at all. This can be a security enhancement,
+# if all processes that need to connect to mysqld run on the same host.
+# All interaction with mysqld must be made via Unix sockets or named pipes.
+# Note that using this option without enabling named pipes on Windows
+# (via the "enable-named-pipe" option) will render mysqld useless!
+# 
+#skip-networking
+
+# Uncomment the following if you are using InnoDB tables
+innodb_file_per_table = on
+innodb_data_home_dir = /var/lib/mysql
+#innodb_data_file_path = ibdata1:2000M;ibdata2:10M:autoextend
+#innodb_log_group_home_dir = /var/lib/mysql
+# You can set .._buffer_pool_size up to 50 - 80 %
+# of RAM but beware of setting memory usage too high
+innodb_buffer_pool_size = 384M
+innodb_additional_mem_pool_size = 20M
+# Set .._log_file_size to 25 % of buffer pool size
+#innodb_log_file_size = 100M
+#innodb_log_buffer_size = 8M
+#innodb_flush_log_at_trx_commit = 1
+#innodb_lock_wait_timeout = 50
+
+[mysqldump]
+quick
+max_allowed_packet = 50M
+
+[mysql]
+no-auto-rehash
+# Remove the next comment character if you are not familiar with SQL
+#safe-updates
+
+[myisamchk]
+key_buffer_size = 256M
+sort_buffer_size = 256M
+read_buffer = 2M
+write_buffer = 2M
+
+[mysqlhotcopy]
+interactive-timeout

--- a/modules/mysql/manifests/init.pp
+++ b/modules/mysql/manifests/init.pp
@@ -21,4 +21,14 @@ class mysql {
 		ensure => 'latest'
 	}
 
+	file { 'my.cnf':
+		notify => Service[$mysql_service],
+		path => '/etc/my.cnf',
+		ensure => file,
+		source => 'puppet:///modules/mysql/my.cnf',
+		owner => 'root',
+		group => 'root',
+		mode => 644
+	}
+
 }


### PR DESCRIPTION
The old MySQL configuration for huge servers - 1-2 GB of RAM - ironically match Amazon EC2 micro instances (1.5 GB). :)
