### PR TITLE
Removed SSL stapling

### DIFF
--- a/modules/nginx/files/nginx.conf
+++ b/modules/nginx/files/nginx.conf
@@ -41,10 +41,6 @@ http {
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
     ssl_prefer_server_ciphers   on;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    resolver 8.8.4.4 8.8.8.8 valid=300s;
-    resolver_timeout 10s;
     # Thanks to: http://nginx.org/en/docs/http/configuring_https_servers.html
     ssl_session_cache   shared:SSL:1m;
     ssl_session_timeout 10m;


### PR DESCRIPTION
Since stapling is specific to SSL certificate
issuer, this might cause problems to general
public.  Disabling for now.
